### PR TITLE
Removed deprecated APIs and constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Thumbs.db
 .project
 .cproject
 builtins
+/.editor_settings

--- a/render/3D.render_script
+++ b/render/3D.render_script
@@ -37,10 +37,10 @@ function init(self)
     self.model_pred = render.predicate({"model"})
     
     self.clear_color = vmath.vector4(0, 0, 0, 0)
-    self.clear_color.x = sys.get_config("render.clear_color_red", 0)
-    self.clear_color.y = sys.get_config("render.clear_color_green", 0)
-    self.clear_color.z = sys.get_config("render.clear_color_blue", 0)
-    self.clear_color.w = sys.get_config("render.clear_color_alpha", 0)
+    self.clear_color.x = sys.get_config_number("render.clear_color_red", 0)
+    self.clear_color.y = sys.get_config_number("render.clear_color_green", 0)
+    self.clear_color.z = sys.get_config_number("render.clear_color_blue", 0)
+    self.clear_color.w = sys.get_config_number("render.clear_color_alpha", 0)
 
     self.view = vmath.matrix4()
 
@@ -60,7 +60,7 @@ function update(self)
     
     render.set_depth_mask(true)
     render.set_stencil_mask(0xff)
-    render.clear({[render.BUFFER_COLOR_BIT] = self.clear_color, [render.BUFFER_DEPTH_BIT] = 1, [render.BUFFER_STENCIL_BIT] = 0})
+    render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = self.clear_color, [graphics.BUFFER_TYPE_DEPTH_BIT] = 1, [graphics.BUFFER_TYPE_STENCIL_BIT] = 0})
 
     render.set_viewport(0, 0, window_width, window_height)
     render.set_view(self.view)
@@ -68,25 +68,25 @@ function update(self)
 
     -- render models
     --
-    render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
-    render.enable_state(render.STATE_BLEND)
-    render.enable_state(render.STATE_STENCIL_TEST)
-    render.enable_state(render.STATE_DEPTH_TEST)
+    render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
+    render.enable_state(graphics.STATE_BLEND)
+    render.enable_state(graphics.STATE_STENCIL_TEST)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
     render.set_depth_mask(true)
     render.draw(self.model_pred, {frustum = frustum_component})
     render.set_depth_mask(false)
-    render.disable_state(render.STATE_DEPTH_TEST)
-    render.disable_state(render.STATE_STENCIL_TEST)
+    render.disable_state(graphics.STATE_DEPTH_TEST)
+    render.disable_state(graphics.STATE_STENCIL_TEST)
     
     -- render sprites, label, particles
     --
 
-    render.enable_state(render.STATE_DEPTH_TEST)
-    render.enable_state(render.STATE_STENCIL_TEST)
+    render.enable_state(graphics.STATE_DEPTH_TEST)
+    render.enable_state(graphics.STATE_STENCIL_TEST)
     render.draw(self.tile_pred, {frustum = frustum_component})
     render.draw(self.particle_pred, {frustum = frustum_component})
-    render.disable_state(render.STATE_STENCIL_TEST)
-    render.disable_state(render.STATE_DEPTH_TEST)
+    render.disable_state(graphics.STATE_STENCIL_TEST)
+    render.disable_state(graphics.STATE_DEPTH_TEST)
 
     -- debug
     render.draw_debug3d()
@@ -100,10 +100,10 @@ function update(self)
     render.set_view(view_gui)
     render.set_projection(proj_gui)
 
-    render.enable_state(render.STATE_STENCIL_TEST)
+    render.enable_state(graphics.STATE_STENCIL_TEST)
     render.draw(self.gui_pred, {frustum = frustum_gui})
-    render.disable_state(render.STATE_STENCIL_TEST)
-    render.disable_state(render.STATE_BLEND)
+    render.disable_state(graphics.STATE_STENCIL_TEST)
+    render.disable_state(graphics.STATE_BLEND)
 end
 
 function on_message(self, message_id, message)


### PR DESCRIPTION
In Defold 1.13.0 deprecated APIs are removed and this sample project should be updated not to use them:

https://github.com/defold/defold/pull/12441